### PR TITLE
[lotto] feat: Add domain-level validation to BonusNumber and clarify SRP-based separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [x] The user inputs one bonus number
 - [x] The bonus number must not be duplicated with winning numbers
 - [x] Validate 6 winning numbers: count, duplicates, range
+- [x] BonusNumber class also performs validation to protect domain integrity (domain layer, **SRP**)
 
 ### 4️⃣ Result Check
 
@@ -44,7 +45,9 @@
 
    → ✅ `InputValidator` class: non-numeric input, bonus duplication, invalid count/range
 
-   →✅ `WinningNumber` class: duplicates, invalid count, out-of-range numbers
+   → ✅ `WinningNumber` class: duplicates, invalid count, out-of-range numbers
+
+   → ✅ `BonusNumber` class : out-of-range numbers,  duplicates
 
 - [ ] All error messages must start with `[ERROR]`  
   → ✅ Exception validation added,  Message prefix application remaining

--- a/src/main/kotlin/lotto/domain/BonusNumber.kt
+++ b/src/main/kotlin/lotto/domain/BonusNumber.kt
@@ -1,0 +1,16 @@
+package lotto.domain
+
+class BonusNumber(private val bonus: Int, private val winningNumbers: List<Int>) {
+
+    init {
+        require(bonus in MIN_NUMBER..MAX_NUMBER) { "[ERROR] Bonus number must be between $MIN_NUMBER and $MAX_NUMBER." }
+        require(bonus !in winningNumbers) { "[ERROR] Bonus number must not duplicate winning numbers." }
+    }
+
+    fun get(): Int = bonus
+
+    companion object{
+        private const val MIN_NUMBER = 1
+        private const val MAX_NUMBER = 45
+    }
+}

--- a/src/main/kotlin/lotto/view/InputView.kt
+++ b/src/main/kotlin/lotto/view/InputView.kt
@@ -22,4 +22,9 @@ class InputView {
         val input = Console.readLine()
         return inputValidator.validateBonusNumber(input, listOf())
     }
+    /*[Single Responsibility Principle - InputView vs BonusNumber]
+    *  InputView is responsible for handling user input and providing user-friendly validation messages
+    *  whereas BonusNumber as a domain object must ensure its own validity upon creation to preserve domain integrity
+    *  the domain object must defensively guarantee that it is never created with invalid values
+    * */
 }

--- a/src/test/kotlin/lotto/domain/BonusNumberTest.kt
+++ b/src/test/kotlin/lotto/domain/BonusNumberTest.kt
@@ -1,0 +1,30 @@
+package lotto.domain
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+class BonusNumberTest {
+    private val winningNumber = listOf(1, 2, 4, 5, 6, 7)
+
+    @Test
+    fun `throws exception when bonus number is out of range`() {
+        // given
+        val invalidBonus = 99
+
+        // when & then
+        assertThatThrownBy { BonusNumber(invalidBonus, winningNumber) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Bonus number must be between")
+    }
+
+    @Test
+    fun `throws exception when bonus number duplicates winning numbers`() {
+        // given
+        val duplicateBonus = 1
+
+        // when & then
+        assertThatThrownBy { BonusNumber(duplicateBonus, winningNumber) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Bonus number must not duplicate winning numbers")
+    }
+}


### PR DESCRIPTION
### 📝 Summary
This PR adds validation logic to the `BonusNumber` class to ensure its integrity within the domain layer.  
While the `InputView` and `InputValidator` already perform input-level validation,  
this change ensures that `BonusNumber` is never created in an invalid state — following the Single Responsibility Principle (SRP).  
The goal is to clearly separate concerns between input handling and domain logic.

### ✅ Features
- Added range (1–45) and duplication validation to `BonusNumber` constructor
- Wrote explanatory comments to describe the reason for duplicate validation
- Applied SRP to reinforce defensive programming at the domain level

### 🧪 Test
- Added unit tests to ensure `BonusNumber` throws exceptions for invalid input
- Verified valid bonus numbers are correctly instantiated