### PR TITLE
[lotto] feat: Implement WinningResult for Rank aggregation and add match logic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 
 ### 4️⃣ Result Check
 
-- [ ] Determine the prize rank based on the number of matching numbers
-- [ ] 3 or more matches qualify for a prize
-- [ ] 2nd prize is for 5 matches + the bonus number
+- [x] Determine the prize rank based on the number of matching numbers
+- [x] 3 or more matches qualify for a prize
+- [x] 2nd prize is for 5 matches + the bonus number
 - [ ] Calculate profit rate = (Total Winnings / Purchase Amount) * 100.0
 
 ### 5️⃣ Exception Handling
@@ -51,3 +51,12 @@
 
 - [ ] All error messages must start with `[ERROR]`  
   → ✅ Exception validation added,  Message prefix application remaining
+
+### 🔍 Test Coverage
+
+- [x] Lotto class validation
+- [x] Money class validation
+- [x] Input validation (InputView + InputValidator)
+- [x] WinningNumber validation
+- [x] WinningNumber.match() → Retrun Rank
+- [ ] WinningResult → Rank-wise statistics test

--- a/src/main/kotlin/lotto/domain/Rank.kt
+++ b/src/main/kotlin/lotto/domain/Rank.kt
@@ -1,0 +1,27 @@
+package lotto.domain
+
+enum class Rank(
+    val matchCount: Int,
+    val prize: Int,
+    val matchBonus: Boolean = false
+) {
+    FIRST(RankConstants.MATCH_6, RankConstants.PRIZE_FIRST),
+    SECOND(RankConstants.MATCH_5, RankConstants.PRIZE_SECOND, true),
+    THIRD(RankConstants.MATCH_5, RankConstants.PRIZE_THIRD),
+    FOURTH(RankConstants.MATCH_4, RankConstants.PRIZE_FOURTH),
+    FIFTH(RankConstants.MATCH_3, RankConstants.PRIZE_FIFTH),
+    NONE(RankConstants.MATCH_0, RankConstants.PRIZE_NONE);
+
+    companion object {
+        fun valueOf(matchCount: Int, matchBonus: Boolean): Rank {
+            return when {
+                matchCount == RankConstants.MATCH_6 -> FIRST
+                matchCount == RankConstants.MATCH_5 && matchBonus -> SECOND
+                matchCount == RankConstants.MATCH_5 -> THIRD
+                matchCount == RankConstants.MATCH_4 -> FOURTH
+                matchCount == RankConstants.MATCH_3 -> FIFTH
+                else -> NONE
+            }
+        }
+    }
+}

--- a/src/main/kotlin/lotto/domain/RankConstants.kt
+++ b/src/main/kotlin/lotto/domain/RankConstants.kt
@@ -1,0 +1,17 @@
+package lotto.domain
+
+object RankConstants {
+    const val MATCH_6 = 6
+    const val MATCH_5 = 5
+    const val MATCH_4 = 4
+    const val MATCH_3 = 3
+    const val MATCH_0 = 0
+
+    // Underscores are used to improve numeric readability
+    const val PRIZE_FIRST = 2_000_000_000
+    const val PRIZE_SECOND = 30_000_000
+    const val PRIZE_THIRD = 1_500_000
+    const val PRIZE_FOURTH = 50_000
+    const val PRIZE_FIFTH = 5_000
+    const val PRIZE_NONE = 0
+}

--- a/src/main/kotlin/lotto/domain/WinningNumber.kt
+++ b/src/main/kotlin/lotto/domain/WinningNumber.kt
@@ -1,6 +1,9 @@
 package lotto.domain
 
-class WinningNumber(private val numbers: List<Int>) {
+import lotto.Lotto
+
+class WinningNumber(private val numbers: List<Int>, private val bonusNumber: Int) {
+
     // Validates the user input for last week lotto winning numbers
     init {
         require(numbers.size == REQUIRED_SIZE) {
@@ -12,6 +15,12 @@ class WinningNumber(private val numbers: List<Int>) {
         require(numbers.all { it in MIN_NUMBER..MAX_NUMBER }) {
             "[ERROR] Winning numbers must be between $MIN_NUMBER and $MAX_NUMBER."
         }
+    }
+
+    fun match(lotto: Lotto): Rank {
+        val matchCount = lotto.getNumbers().count { it in numbers }
+        val hasBonus = lotto.getNumbers().contains(bonusNumber)
+        return Rank.valueOf(matchCount, hasBonus)
     }
 
     /*

--- a/src/main/kotlin/lotto/domain/WinningResult.kt
+++ b/src/main/kotlin/lotto/domain/WinningResult.kt
@@ -1,0 +1,21 @@
+package lotto.domain
+
+import lotto.Lotto
+
+class WinningResult(private val ranks: List<Rank>) {
+
+    fun getStatistics(): Map<Rank, Int> {
+        return ranks.groupingBy { it }.eachCount()
+    }
+
+    fun getCountOf(rank: Rank): Int {
+        return ranks.count { it == rank }
+    }
+
+    companion object {
+        fun of(lottos: List<Lotto>, winningNumber: WinningNumber): WinningResult {
+            val ranks = lottos.map { winningNumber.match(it) }
+            return WinningResult(ranks)
+        }
+    }
+}

--- a/src/test/kotlin/lotto/domain/WinningNumberTest.kt
+++ b/src/test/kotlin/lotto/domain/WinningNumberTest.kt
@@ -1,5 +1,7 @@
 package lotto.domain
 
+import lotto.Lotto
+import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
@@ -9,9 +11,10 @@ class WinningNumberTest {
     fun `throws exception when there are not exactly 6 winning numbers`() {
         // given
         val numbers = listOf(1, 2, 3, 4, 5)
+        val bonus = 6
 
         // when & then
-        assertThatThrownBy { WinningNumber(numbers) }
+        assertThatThrownBy { WinningNumber(numbers, bonus) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("[ERROR] Winning numbers must consist of exactly 6 numbers.")
     }
@@ -20,8 +23,9 @@ class WinningNumberTest {
     fun `throws exception when there are duplicate numbers`() {
         // given
         val numbers = listOf(1, 2, 3, 4, 5, 5)
+        val bonus = 6
 
-        assertThatThrownBy { WinningNumber(numbers) }
+        assertThatThrownBy { WinningNumber(numbers, bonus) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Winning numbers must be unique")
     }
@@ -30,10 +34,77 @@ class WinningNumberTest {
     fun `throws exception when numbers are out of range`() {
         // given
         val numbers = listOf(0, 2, 3, 4, 5, 46)
+        val bonus = 6
 
         // when & then
-        assertThatThrownBy { WinningNumber(numbers) }
+        assertThatThrownBy { WinningNumber(numbers, bonus) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("Winning numbers must be between 1 and 45")
     }
+
+    @Test
+    fun `all 6 numbers match and bonus number is not included when match is called Then Rank is FIRST`() {
+        // given
+        val winningNumber = WinningNumber(listOf(1, 2, 3, 4, 5, 6), bonusNumber = 7)
+        val lotto = Lotto(listOf(1, 2, 3, 4, 5, 6))
+
+        // when
+        val result = winningNumber.match(lotto)
+
+        // then
+        assertThat(result).isEqualTo(Rank.FIRST)
+    }
+
+    @Test
+    fun `5 numbers match and the bonus number also matches when match is called Then Rank is SECOND`() {
+        // given
+        val winningNumber = WinningNumber(listOf(1, 2, 3, 4, 5, 6), bonusNumber = 7)
+        val lotto = Lotto(listOf(1, 2, 3, 4, 5, 7))
+
+        // when
+        val result = winningNumber.match(lotto)
+
+        // then
+        assertThat(result).isEqualTo(Rank.SECOND)
+    }
+
+    @Test
+    fun `5 numbers match and the bonus number does not match when match is called Then Rank is THIRD`() {
+        // given
+        val winningNumber = WinningNumber(listOf(1, 2, 3, 4, 5, 6), bonusNumber = 7)
+        val lotto = Lotto(listOf(1, 2, 3, 4, 5, 8))
+
+        // when
+        val result = winningNumber.match(lotto)
+
+        // Then
+        assertThat(result).isEqualTo(Rank.THIRD)
+    }
+
+    @Test
+    fun `3 numbers match when match is called Then Rank is FIFT`() {
+        // given
+        val winningNumber = WinningNumber(listOf(1, 2, 3, 4, 5, 6), bonusNumber = 7)
+        val lotto = Lotto(listOf(1, 2, 3, 10, 11, 12))
+
+        // when
+        val result = winningNumber.match(lotto)
+
+        // then
+        assertThat(result).isEqualTo(Rank.FIFTH)
+    }
+
+    @Test
+    fun `no numbers match when match is called Then Rank is NONE`() {
+        // Given
+        val winningNumber = WinningNumber(listOf(1, 2, 3, 4, 5, 6), bonusNumber = 7)
+        val lotto = Lotto(listOf(10, 11, 12, 13, 14, 15))
+
+        // when
+        val result = winningNumber.match(lotto)
+
+        // then
+        assertThat(result).isEqualTo(Rank.NONE)
+    }
 }
+

--- a/src/test/kotlin/lotto/domain/WinningResultTest.kt
+++ b/src/test/kotlin/lotto/domain/WinningResultTest.kt
@@ -1,0 +1,37 @@
+import lotto.Lotto
+import lotto.domain.Rank
+import lotto.domain.WinningNumber
+import lotto.domain.WinningResult
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class WinningResultTest {
+
+    @Test
+    fun `Given multiple lottos When compared with winning numbers Then returns the count of each rank`() {
+        // given
+        val lottos = listOf(
+            Lotto(listOf(1, 2, 3, 4, 5, 6)), // 6 matches - 1st rank
+            Lotto(listOf(1, 2, 3, 4, 5, 7)), // 5 matches + bonus - 2nd rank
+            Lotto(listOf(1, 2, 3, 4, 5, 8)), // 5 matches - 3rd rank
+            Lotto(listOf(1, 2, 3, 4, 10, 11)), // 4 matches - 4th rank
+            Lotto(listOf(1, 2, 3, 9, 10, 11)), // 3 matches - 5th rank
+            Lotto(listOf(20, 21, 22, 23, 24, 25)) // 0 matches - no prize
+        )
+
+        val winningNumbers = listOf(1, 2, 3, 4, 5, 6)
+        val bonusNumber = 7
+        val winningNumber = WinningNumber(winningNumbers, bonusNumber)
+
+        // when
+        val result = WinningResult.of(lottos, winningNumber)
+
+        // then
+        assertThat(result.getCountOf(Rank.FIRST)).isEqualTo(1)
+        assertThat(result.getCountOf(Rank.SECOND)).isEqualTo(1)
+        assertThat(result.getCountOf(Rank.THIRD)).isEqualTo(1)
+        assertThat(result.getCountOf(Rank.FOURTH)).isEqualTo(1)
+        assertThat(result.getCountOf(Rank.FIFTH)).isEqualTo(1)
+        assertThat(result.getCountOf(Rank.NONE)).isEqualTo(1)
+    }
+}


### PR DESCRIPTION
## 📌 Summary  
- Implements the `WinningResult` domain class to aggregate the match results of multiple Lotto tickets  
- Enhances `WinningNumber.match()` test coverage to ensure correct `Rank` evaluation for all matching scenarios  
- All tests are written in GWT (Given-When-Then) format using JUnit 5 and AssertJ

---

## ✅ Features  
**WinningResult**
- `of(lottos: List<Lotto>, winningNumber: WinningNumber): WinningResult` factory method to generate result summary  
- `getCountOf(rank: Rank): Int` returns the number of matches for a given `Rank`

**WinningNumber**
- `match(lotto: Lotto): Rank` compares a lotto ticket with the winning numbers and returns the corresponding prize rank

---

## 🧪 Test  
**WinningResultTest**
- Validates rank counts using a predefined list of Lotto tickets representing all possible ranks:  
  - FIRST (6 matches)  
  - SECOND (5 + bonus)  
  - THIRD (5 matches)  
  - FOURTH (4 matches)  
  - FIFTH (3 matches)  
  - NONE (no matches)

**WinningNumberTest**
- Verifies `match()` returns the correct `Rank` for each scenario:  
  - [x] 6 numbers match → FIRST  
  - [x] 5 numbers + bonus → SECOND  
  - [x] 5 numbers match → THIRD  
  - [x] 3 numbers match → FIFTH  
  - [x] No numbers match → NONE
