### PR TITLE
[lotto] feat: add ProfitCalculator to compute profit rate from statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 - [x] Determine the prize rank based on the number of matching numbers
 - [x] 3 or more matches qualify for a prize
 - [x] 2nd prize is for 5 matches + the bonus number
-- [ ] Calculate profit rate = (Total Winnings / Purchase Amount) * 100.0
+- [x] Calculate profit rate = (Total Winnings / Purchase Amount) * 100.0
 
 ### 5️⃣ Exception Handling
 

--- a/src/main/kotlin/lotto/domain/ProfitCalculator.kt
+++ b/src/main/kotlin/lotto/domain/ProfitCalculator.kt
@@ -1,0 +1,14 @@
+package lotto.domain
+
+object ProfitCalculator {
+
+    fun calculate(statistics: Map<Rank, Int>, purchaseAmount: Int): Double {
+        require(purchaseAmount > 0) { "[ERROR] Purchase amount must be greater than 0" }
+
+        val totalPrize = statistics.entries.sumOf { (rank, count) ->
+            rank.prize * count
+        }
+
+        return (totalPrize.toDouble() / purchaseAmount) * 100
+    }
+}

--- a/src/test/kotlin/lotto/domain/ProfitCalculatorTest.kt
+++ b/src/test/kotlin/lotto/domain/ProfitCalculatorTest.kt
@@ -1,0 +1,29 @@
+package lotto.domain
+
+import lotto.domain.ProfitCalculator
+import lotto.domain.Rank
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ProfitCalculatorTest {
+
+    @Test
+    fun `calculate profit rate based on statistics and purchase amount`() {
+        // given
+        val statistics = mapOf(
+            Rank.FIFTH to 1,      // 3 Matches – 5,000 KRW
+            Rank.FOURTH to 0,     // 4 Matches
+            Rank.THIRD to 0,      // 5 Matches
+            Rank.SECOND to 0,     // 5 Matches + Bonus
+            Rank.FIRST to 0,      // 6 Matches
+            Rank.NONE to 0        // No matches
+        )
+        val purchaseAmount = 8_000
+
+        // when
+        val profitRate = ProfitCalculator.calculate(statistics, purchaseAmount)
+
+        // then
+        assertThat(profitRate).isEqualTo(62.5)
+    }
+}


### PR DESCRIPTION
## 📌 Summary  
Adds a dedicated `ProfitCalculator` object to encapsulate the logic for computing profit rate  
based on the result statistics and purchase amount.  
This logic is separated from the domain entity to respect SRP and improve reusability.

---

## ✅ Features  
- Created `ProfitCalculator` as a stateless utility object  
- Method: `calculate(statistics: Map<Rank, Int>, purchaseAmount: Int): Double`  
- Throws exception when purchase amount is 0 or negative

---

## 🧪 Test  
- Added `ProfitCalculatorTest`  
- Verified that the following case produces an exact 62.5% profit rate:
3 Matches (5,000 KRW) – 1 tickets
4 Matches (50,000 KRW) – 0 tickets
5 Matches (1,500,000 KRW) – 0 tickets
5 Matches + Bonus Ball (30,000,000 KRW) – 0 tickets
6 Matches (2,000,000,000 KRW) – 0 tickets
Total return rate is 62.5%
